### PR TITLE
[NO-TICKET] pin build to JDK 21 via Maven toolchain and modernize CI

### DIFF
--- a/.github/workflows/.github-ci.yml
+++ b/.github/workflows/.github-ci.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 target
 src/main/java/ecommerce/Runner.java
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,7 @@
   <name>ECommerce-Control-Plane-Function</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
   <dependencies>
     <dependency>
@@ -74,6 +73,25 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-toolchains-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <toolchains>
+            <jdk>
+              <version>21</version>
+            </jdk>
+          </toolchains>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>toolchain</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.2</version>
       </plugin>
@@ -109,8 +127,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-           <source>17</source>
-           <target>17</target>
+           <release>17</release>
           <annotationProcessorPaths>
             <path>
               <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
  Fix Lombok 1.18.36 failing under JDK 25 (TypeTag :: UNKNOWN) by requiring   
  a JDK 21 toolchain for this project, independent of the shell's JAVA_HOME.  
                                                                              
  - Add maven-toolchains-plugin requiring JDK 21 (matches the Lambda runtime) 
  - Switch compiler config from source/target to release 17 for stricter      
    API-level checks while keeping Java 17 bytecode                           
  - Bump actions/checkout v3->v4 and actions/setup-java v2->v4 (EOL Node);    
    setup-java still auto-provides the JDK 21 toolchain on CI                 
  - Ignore .DS_Store                                                          
                                                                              
  Requires a JDK 21 entry in ~/.m2/toolchains.xml for local builds. 