### PR TITLE
[NO-TICKET] remediate dependency CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-crypto</artifactId>
-      <version>6.4.1</version>
+      <version>6.4.13</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -30,6 +30,12 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
       <version>2.29.52</version>
+      <exclusions>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>netty-nio-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -44,7 +50,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.2</version>
+      <version>2.18.9</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
  Resolve known vulnerabilities flagged on transitive and direct deps.        
                                                                              
  - spring-security-crypto 6.4.1 -> 6.4.13 (CVE-2025-22228: BCrypt now        
    rejects passwords > 72 bytes instead of silently truncating)              
  - jackson-databind 2.18.2 -> 2.18.9 (pulls patched jackson-core)            
  - Exclude unused netty-nio-client from the s3 dependency, removing all      
    Netty CVEs (request smuggling, HTTP/2 DoS, TLS crash). The app uses       
    the sync UrlConnectionHttpClient + S3Presigner, so the async Netty        
    client was never used at runtime.