### PR TITLE
[NO-TICKET] exclude netty-nio-client from dynamodb-enhanced

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,12 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>dynamodb-enhanced</artifactId>
       <version>2.29.43</version>
+      <exclusions>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>netty-nio-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>


### PR DESCRIPTION
  Completes the Netty CVE removal from PR #12, which only excluded the        
  async client from the s3 dependency. dynamodb-enhanced still pulled it      
  in transitively via dynamodb, so vulnerable io.netty jars still shipped.    
  The app uses UrlConnectionHttpClient + S3Presigner, so the async Netty      
  client is unused